### PR TITLE
add github actions ci

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,39 @@
+name: Alfred Jenkins CI
+
+on:
+  pull_request:
+    branches:
+      - master
+    tags-ignore:
+      - '*'
+  push:
+    branches:
+      - master
+    tags-ignore:
+      - '*'
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup GraalVM
+        uses: olafurpg/setup-scala@v7
+        with:
+          java-version: graalvm-ce-java11@20.1.0
+      - name: Install native-image
+        run: gu install native-image
+      - name: Print versions
+        run: |
+          java -version
+          native-image --version
+      - name: Run tests
+        run:  sbt workflow/clean workflow/test
+      - name: Package
+        run: sbt workflow/alfredWorkflowPackage
+#      - uses: codecov/codecov-action@v1
+#        with:
+#          token: ${{ secrets.CODECOV_TOKEN }}
+#          file: ./modules/codegen/target/scala-2.12/scoverage-report/scoverage.xml
+#          fail_ci_if_error: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,26 @@
+name: Alfred Jenkins Release
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  release:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup GraalVM
+        uses: olafurpg/setup-scala@v7
+        with:
+          java-version: graalvm-ce-java11@20.1.0
+      - name: Install native-image
+        run: gu install native-image
+      - name: Print versions
+        run: |
+          java -version
+          native-image --version
+      - name: Package and Release
+        run: sbt githubRelease
+

--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,7 @@ lazy val `alfred-jenkins` = (project in file("."))
 lazy val `workflow` = (project in file("workflow"))
   .settings(
     name := "alfred-jenkins",
-    graalVMNativeImageCommand := "/Users/elias.jordan/graalvm-ce-java11-20.1.0/Contents/Home/bin/native-image",
+//    graalVMNativeImageCommand := "/Users/elias.jordan/graalvm-ce-java11-20.1.0/Contents/Home/bin/native-image",
     graalVMNativeImageOptions := Seq(
       "--verbose",
       "-H:+TraceClassInitialization",

--- a/notes/0.0.1.md
+++ b/notes/0.0.1.md
@@ -6,5 +6,5 @@ This release includes:
 - The ability to drill into the build history of a job.
 - The ability to search all jobs on a jenkins server.
 - Keychain access, to save the jenkins password.
-- Graal native image build binary, to allow snappy response times
+- Graal native image based binary, to allow snappy response times.
 - File-system based caching, to allow snappy response times.

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,5 +4,8 @@ addSbtPlugin("com.dwijnand"      % "sbt-dynver"          % "4.1.1")
 
 libraryDependencies ++= Seq(
   // Used by AlfredWorkflowPlugin
-  "com.googlecode.plist" % "dd-plist" % "1.23"
+  "com.googlecode.plist" % "dd-plist" % "1.23",
+
+  // For JDK 11
+  "com.sun.activation" % "javax.activation" % "1.2.0"
 )


### PR DESCRIPTION
Adds two github actions workflows. 
1. Runs tests and ensures native image packaging works
2. When a tag is pushed, creates a publishes a release to GH releases